### PR TITLE
feat: Added addListener method

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,9 +1,12 @@
+import { type PluginListenerHandle } from "@capacitor/core";
+
 export interface MetaMapParams {
   clientId: string
   flowId: string
   metadata?: object
 }
 export interface MetaMapCapacitorPlugin {
+  addListener(eventName: 'verificationCreated', listenerFunc: (data: { identityId: string, verificationID: string }) => any): Promise<PluginListenerHandle>;
   showMetaMapFlow(options: MetaMapParams): Promise<{ identityId: string, verificationID: string }>;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import type { MetaMapParams } from './definitions';
 const MetaMapCapacitorUnwrapped = registerPlugin<MetaMapCapacitorPlugin>('MetaMapCapacitor', {});
 
 const MetaMapCapacitor = {
+    addEventListener: MetaMapCapacitorUnwrapped.addListener,
     showMetaMapFlow: function(options: MetaMapParams):Promise<{ identityId: string, verificationID: string }> {
         const { metadata } = options
         return MetaMapCapacitorUnwrapped.showMetaMapFlow({...options, metadata: {...metadata, sdkType: "capacitor" }})
@@ -15,4 +16,4 @@ const MetaMapCapacitor = {
 
 export * from './definitions';
 export { MetaMapCapacitor };
-  
+


### PR DESCRIPTION
The implementation examples on the MetaMap documentation mentions the `addListener` method, but it is currently not present in the current version of the library.

This PR adds this method to match the examples in the docs.